### PR TITLE
Enhance ONNX runtime handling

### DIFF
--- a/ssv_ONNX_BENCHMARK.py
+++ b/ssv_ONNX_BENCHMARK.py
@@ -176,7 +176,8 @@ def main():
         print(f"Max time/frame: {max(times)*1000:.1f} ms")
 
         print(f"Average FPS: {avg_fps:.2f}")
-        imageio.mimsave(output_path, frames, fps=avg_fps)
+        if frames:
+            imageio.mimsave(output_path, frames, fps=avg_fps)
     else:
         print("No frames were processed.")
 


### PR DESCRIPTION
## Summary
- avoid debug output during ONNX model setup
- initialize `using_fp16` flag and ensure tensors are moved to GPU when using FP16
- allocate output buffers using the model's precision
- save video only when frames were collected
- simplify ONNX FP16 conversion to use built-in converter

## Testing
- `python -m py_compile vision_preprocess_alternate.py ssv_ONNX_BENCHMARK.py`


------
https://chatgpt.com/codex/tasks/task_e_687085749d3083299b060bb8aa9cc425